### PR TITLE
Switch backend deployment to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 1. `cd backend`
 2. `python -m venv .venv && source .venv/bin/activate`
 3. `pip install -e .[dev]`
-4. Скопируйте `.env.example` в `.env` и укажите доступ к MySQL.
+4. Скопируйте `.env.example` в `.env` и укажите доступ к PostgreSQL.
 5. Примените миграции: `alembic upgrade head`.
 6. Запустите API: `uvicorn app.main:app --reload`
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,8 @@
 
 ## Prerequisites
 - Python 3.10+
-- Running MySQL instance accessible via `PVT_DATABASE_URL`
+- Running PostgreSQL instance accessible via `PVT_DATABASE_URL`
+- Optional: [`pg_cron`](https://github.com/citusdata/pg_cron) extension installed on the target database (used to schedule daily maintenance jobs). If it is unavailable, schedule the maintenance SQL statements manually via an external cron job.
 
 ## Setup
 ```bash

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = mysql+pymysql://user:password@localhost:3306/palsy_db
+sqlalchemy.url = postgresql+psycopg://user:password@localhost:5432/palsy_db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_prefix="PVT_", case_sensitive=False)
 
-    database_url: str = "mysql+pymysql://user:password@localhost:3306/palsy_db"
+    database_url: str = "postgresql+psycopg://user:password@localhost:5432/palsy_db"
 
 
 @lru_cache(maxsize=1)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "alembic",
     "pydantic-settings",
     "python-dotenv",
-    "pymysql",
+    "psycopg[binary]",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- update backend configuration, dependencies, and Alembic defaults to use PostgreSQL via psycopg
- adapt the initial Alembic migration to use PostgreSQL identities and schedule maintenance tasks through pg_cron
- refresh project documentation to reference PostgreSQL setup steps and optional pg_cron requirement

## Testing
- `cd backend && source .venv/bin/activate && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccccefec3883229df09a4c475299bf