### PR TITLE
Use PostgreSQL configuration for backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -e .[dev]
       - name: Run pytest
         env:
-          PVT_DATABASE_URL: mysql+pymysql://root:password@127.0.0.1:3306/palsy_db
+          PVT_DATABASE_URL: postgresql+psycopg://postgres:password@127.0.0.1:5432/palsy_db
         run: pytest
 
   frontend:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,2 @@
 # Example environment configuration for the FastAPI backend
-PVT_DATABASE_URL=mysql+pymysql://user:password@localhost:3306/palsy_db
+PVT_DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/palsy_db


### PR DESCRIPTION
## Summary
- switch the CI backend test run to use a PostgreSQL connection URL
- update the sample environment file to document the PostgreSQL DSN

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccd2d4e16c8322aaa034d902c5166b