### PR TITLE
Configure default PostgreSQL credentials for deployment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,2 @@
 # Example environment configuration for the FastAPI backend
-PVT_DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/palsy_db
+PVT_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/postgres

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql+psycopg://user:password@localhost:5432/palsy_db
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@localhost:5432/postgres
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_prefix="PVT_", case_sensitive=False)
 
-    database_url: str = "postgresql+psycopg://user:password@localhost:5432/palsy_db"
+    database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
 
 
 @lru_cache(maxsize=1)

--- a/deploy/group_vars/prod.yml
+++ b/deploy/group_vars/prod.yml
@@ -5,7 +5,7 @@ venv_path: "{{ app_root }}/venv"
 app_src_path: "{{ app_root }}/src"
 uvicorn_port: 8000
 palsy_domain: "45.67.230.58"
-pvt_database_url: "postgresql+psycopg://user:password@db-host:5432/palsy_db"
+pvt_database_url: "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
 
 nginx_site_path: /etc/nginx/sites-available/palsy-backend.conf
 nginx_site_link: /etc/nginx/sites-enabled/palsy-backend.conf


### PR DESCRIPTION
## Summary
- update backend configuration defaults to use standard postgres/postgres credentials on localhost:5432/postgres
- align Alembic and environment examples with the default connection string
- configure Ansible deployment variables to apply the same default database URL for the remote server

## Testing
- `cd backend && python -m venv .venv && source .venv/bin/activate && pip install -e .[dev] && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccd53f91108322931157babfeb04e5