### PR TITLE
Add deployment workflow for backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy backend
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "backend/**"
+      - "deploy/**"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch or tag) to deploy"
+        required: false
+        default: "main"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    env:
+      DEPLOY_HOST: 45.67.230.58
+      ANSIBLE_CONFIG: ${{ github.workspace }}/deploy/ansible.cfg
+    steps:
+      - name: Determine git ref
+        id: determine-ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.ref }}" ]; then
+            echo "ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.determine-ref.outputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Ansible
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible
+
+      - name: Create CI inventory
+        run: |
+          cat <<INVENTORY > deploy/inventory.ci.ini
+          [prod]
+          palsy_app ansible_host=${{ env.DEPLOY_HOST }} ansible_user=${{ secrets.DEPLOY_SSH_USER }} ansible_password=${{ secrets.DEPLOY_SSH_PASSWORD }} ansible_become_password=${{ secrets.DEPLOY_SSH_BECOME_PASSWORD || secrets.DEPLOY_SSH_PASSWORD }}
+          INVENTORY
+
+      - name: Run deployment playbook
+        env:
+          ANSIBLE_STDOUT_CALLBACK: yaml
+          SECRET_PVT_DATABASE_URL: ${{ secrets.PVT_DATABASE_URL }}
+          SECRET_PALSY_DOMAIN: ${{ secrets.PALSY_DOMAIN }}
+        run: |
+          extra_vars=""
+          if [ -n "$SECRET_PVT_DATABASE_URL" ]; then
+            extra_vars="$extra_vars pvt_database_url='$SECRET_PVT_DATABASE_URL'"
+          fi
+          if [ -n "$SECRET_PALSY_DOMAIN" ]; then
+            extra_vars="$extra_vars palsy_domain='$SECRET_PALSY_DOMAIN'"
+          fi
+
+          if [ -n "$extra_vars" ]; then
+            ansible-playbook -i deploy/inventory.ci.ini deploy/playbooks/deploy_backend.yml --extra-vars "$extra_vars"
+          else
+            ansible-playbook -i deploy/inventory.ci.ini deploy/playbooks/deploy_backend.yml
+          fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the backend to 45.67.230.58
- install Ansible and generate an inventory from deployment secrets before running the existing playbook
- allow optional overrides for database URL and domain via repository secrets

## Testing
- not run (workflow file only)


------
https://chatgpt.com/codex/tasks/task_e_68ccd690a4ec8322a1fab313689bdda0