### PR TITLE
Configure Nginx to serve SPA frontend and proxy API requests

### DIFF
--- a/deploy/group_vars/prod.yml
+++ b/deploy/group_vars/prod.yml
@@ -4,7 +4,8 @@ app_root: /opt/palsy-backend
 venv_path: "{{ app_root }}/venv"
 app_src_path: "{{ app_root }}/src"
 uvicorn_port: 8000
-palsy_domain: "45.67.230.58"
+palsy_domain: "palsy-training.ru"
+frontend_root: /var/www/palsy-training/dist
 pvt_database_url: "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
 
 nginx_site_path: /etc/nginx/sites-available/palsy-backend.conf

--- a/deploy/templates/palsy-backend.nginx.conf.j2
+++ b/deploy/templates/palsy-backend.nginx.conf.j2
@@ -2,7 +2,14 @@ server {
     listen 80;
     server_name {{ palsy_domain }};
 
+    root {{ frontend_root }};
+    index index.html;
+
     location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
         proxy_pass http://127.0.0.1:{{ uvicorn_port }};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- update the production variables to use the palsy-training.ru domain and define the frontend build root
- rewrite the Nginx site template to serve the built SPA from disk and forward /api/ requests to the backend

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_68ccefc045608322874565b87432c32a