### PR TITLE
Add deployment workflow for production server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy via SSH
+    runs-on: ubuntu-latest
+
+    env:
+      SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+      SSH_HOST: 45.67.230.58
+      DEPLOY_PATH: ${{ secrets.DEPLOY_TARGET_PATH }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Ensure required secrets are present
+        run: |
+          if [ -z "$SSH_USER" ]; then
+            echo "DEPLOY_SSH_USER secret is not set" >&2
+            exit 1
+          fi
+          if [ -z "$DEPLOY_PATH" ]; then
+            echo "DEPLOY_TARGET_PATH secret is not set" >&2
+            exit 1
+          fi
+
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add host to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync project files to server
+        run: |
+          rsync -az --delete \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            --exclude '.env' \
+            --exclude '__pycache__/' \
+            --exclude 'node_modules/' \
+            ./ "$SSH_USER@$SSH_HOST:$DEPLOY_PATH"
+
+      - name: Apply docker-compose deployment
+        run: |
+          ssh "$SSH_USER@$SSH_HOST" "DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd "$DEPLOY_PATH"
+          docker compose pull
+          docker compose up -d --build --remove-orphans
+          REMOTE


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the project to 45.67.230.58 via SSH
- validate required secrets and run docker compose to rebuild services on the remote host

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd0bcaab6483229273ab06766b6af6