### PR TITLE
Handle missing database configuration gracefully

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     project_name: str = "myapp"
-    database_url: PostgresDsn
+    database_url: PostgresDsn | None = None
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,14 +1,39 @@
 from collections.abc import AsyncGenerator
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import get_settings
 
-settings = get_settings()
-engine = create_async_engine(settings.database_url, echo=False, future=True)
-AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _get_session_factory() -> async_sessionmaker[AsyncSession]:
+    global _engine, _session_factory
+
+    if _session_factory is None:
+        try:
+            settings = get_settings()
+        except ValidationError as exc:  # pragma: no cover - defensive configuration guard
+            raise RuntimeError("DATABASE_URL is not configured") from exc
+
+        if settings.database_url is None:
+            raise RuntimeError("DATABASE_URL is not configured")
+
+        _engine = create_async_engine(str(settings.database_url), echo=False, future=True)
+        _session_factory = async_sessionmaker(bind=_engine, expire_on_commit=False, class_=AsyncSession)
+
+    assert _session_factory is not None  # for type checkers
+    return _session_factory
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    async with AsyncSessionLocal() as session:
+    try:
+        session_factory = _get_session_factory()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    async with session_factory() as session:
         yield session


### PR DESCRIPTION
## Summary
- allow the backend settings to load even when the database URL is not configured
- lazily initialize the async SQLAlchemy engine and return a 503 error when no database URL is provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6fdee2e48322b498de7054679baf