### PR TITLE
Set frontend container user and export IDs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,5 +61,7 @@ jobs:
           set -euo pipefail
           cd "$DEPLOY_PATH"
           docker compose pull
+          export UID=$(id -u)
+          export GID=$(id -g)
           docker compose up -d --build --remove-orphans
           REMOTE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   frontend:
     image: node:20-alpine
     working_dir: /app
+    user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ./frontend:/app
       - frontend-node-modules:/app/node_modules


### PR DESCRIPTION
## Summary
- configure the frontend compose service to run as the invoking UID/GID via environment defaults
- export UID and GID in the deployment SSH script before running docker compose up so those values propagate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d35ba9a8a08322870b772705b5c7dc