### PR TITLE
Set frontend container user and export IDs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           set -euo pipefail
           cd "$DEPLOY_PATH"
           docker compose pull
-          export UID=$(id -u)
-          export GID=$(id -g)
+          export APP_UID=$(id -u)
+          export APP_GID=$(id -g)
           docker compose up -d --build --remove-orphans
           REMOTE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   frontend:
     image: node:20-alpine
     working_dir: /app
-    user: "${UID:-1000}:${GID:-1000}"
+    user: "${APP_UID:-1000}:${APP_GID:-1000}"
     volumes:
       - ./frontend:/app
       - frontend-node-modules:/app/node_modules


### PR DESCRIPTION
## Summary
- rename exported UID/GID variables in the deploy workflow to APP_UID/APP_GID to avoid readonly bash variable errors
- update docker compose frontend service to consume APP_UID/APP_GID defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d35ce5b1648322a87259434c0278c9