### PR TITLE
Adjust deploy workflow to run frontend build separately

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,5 +63,6 @@ jobs:
           docker compose pull
           export APP_UID=$(id -u)
           export APP_GID=$(id -g)
-          docker compose up -d --build --remove-orphans
+          docker compose run --rm -T frontend
+          docker compose up -d --build --remove-orphans db backend caddy
           REMOTE


### PR DESCRIPTION
## Summary
- update deployment script to run the frontend build as a one-off task
- ensure docker compose only keeps runtime services running after build completes

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3608790888322a7050b32f3bbae5d