### PR TITLE
Build frontend assets during Docker image build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,31 +28,18 @@ services:
       timeout: 5s
       retries: 5
 
-  frontend:
-    image: node:20-alpine
-    user: "${APP_UID:-1000}:${APP_GID:-1000}"
-    working_dir: /app
-    environment:
-      - HOME=/tmp
-      - NPM_CONFIG_CACHE=/tmp/.npm
-    volumes:
-      - ./frontend:/app
-      - frontend-node-modules:/app/node_modules
-    command: sh -c "npm ci && npm run build"
-
   caddy:
-    image: caddy:2
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
     depends_on:
       backend:
         condition: service_started
-      frontend:
-        condition: service_completed_successfully
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./frontend/dist:/srv:ro
       - media-data:/media
       - caddy-data:/data
       - caddy-config:/config
@@ -62,4 +49,3 @@ volumes:
   media-data:
   caddy-data:
   caddy-config:
-  frontend-node-modules:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm ci
+
+FROM node:20-alpine AS build
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY frontend/ .
+RUN npm run build
+
+FROM caddy:2
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /srv


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that installs frontend dependencies and builds the production bundle
- update docker-compose to build the caddy image from the new Dockerfile and drop the node_modules volume
- add a .dockerignore to keep build artifacts and dependencies out of the Docker build context

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36647d7ec8322984abd2a140512b9