### PR TITLE
Fix deploy workflow to match compose services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,5 @@ jobs:
           docker compose pull
           export APP_UID=$(id -u)
           export APP_GID=$(id -g)
-          docker compose run --rm -T frontend
           docker compose up -d --build --remove-orphans db backend caddy
           REMOTE


### PR DESCRIPTION
## Summary
- remove the docker compose run step for the non-existent frontend service in the deploy workflow
- keep the deployment job focused on bringing up the defined services

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d368632a888322a0f727fd93671544