### PR TITLE
Fix Caddy root path to match Docker build output

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,6 @@
 palsy-training.ru {
     # Раздаём собранный фронтенд
-    root * /home/deployer/app/frontend/dist
+    root * /srv
 
     # Сжатие
     encode zstd gzip


### PR DESCRIPTION
## Summary
- point the Caddy root to /srv where the Docker image publishes the frontend build

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d369fb4948832282de0a2599b47991