### PR TITLE
fix: reset selected exercises on patient change

### DIFF
--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
 
 type Disorder = {
   id: number;
@@ -238,6 +238,10 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     minutes: '05',
     seconds: '00',
   });
+
+  useEffect(() => {
+    setSelectedExercises([]);
+  }, [selectedPatientId]);
 
   const selectedPatient = patients.find((patient) => patient.id === selectedPatientId) ?? null;
 


### PR DESCRIPTION
## Summary
- clear the selected exercise list whenever the highlighted patient changes so assignments stay scoped

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d378d5aad0832296b8e65652bf30e1