### PR TITLE
Load doctor dashboard data from database + proxy API requests

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,7 @@
 palsy-training.ru {
+    @api path /api/*
+    reverse_proxy @api backend:8000
+
     # Раздаём собранный фронтенд
     root * /srv
 


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that returns patients, disorders, exercises, appointments and disorder-to-exercise links for the doctor dashboard
- switch the React doctor dashboard to fetch data from the backend, normalise the response and show loading/error states during fetches
- harden the UI logic for missing birth dates and backend-driven recommendations when filtering exercises
- configure Caddy to reverse-proxy /api/* requests to the FastAPI backend so the doctor dashboard fetch succeeds in production

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d38cccdc4c83228def7fcdee4a5cad