### PR TITLE
Load doctor dashboard data from database + proxy API requests (follow-up)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,16 +1,21 @@
 palsy-training.ru {
-    @api path /api/*
-    reverse_proxy @api backend:8000
+    route {
+        handle_path /api/* {
+            reverse_proxy backend:8000
+        }
 
-    # Раздаём собранный фронтенд
-    root * /srv
+        handle {
+            # Раздаём собранный фронтенд
+            root * /srv
 
-    # Сжатие
-    encode zstd gzip
+            # Сжатие
+            encode zstd gzip
 
-    # SPA fallback: если файла нет — отдаём index.html
-    try_files {path} /index.html
+            # SPA fallback: если файла нет — отдаём index.html
+            try_files {path} /index.html
 
-    # Включаем файловый сервер
-    file_server
+            # Включаем файловый сервер
+            file_server
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Caddy routes /api/* requests through reverse_proxy before applying the SPA fallback

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d38ef11b8c83228d089943984bea08