### PR TITLE
Fix API proxy to retain prefix

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,6 @@
 palsy-training.ru {
     route {
-        handle_path /api/* {
+        handle /api/* {
             reverse_proxy backend:8000
         }
 


### PR DESCRIPTION
## Summary
- change the Caddy route to use `handle /api/*` so the `/api` prefix is preserved when proxying to the backend

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d3908fc4c08322bbc2ff0e0993d730