### PR TITLE
Ensure async engine uses asyncpg DSN

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,6 +13,23 @@ class Settings(BaseSettings):
         "env_file_encoding": "utf-8",
     }
 
+    @property
+    def async_database_url(self) -> str:
+        """Return database URL compatible with SQLAlchemy async engines."""
+
+        url = str(self.database_url)
+
+        if "+" in url:
+            return url
+
+        if url.startswith("postgresql://"):
+            return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+        if url.startswith("postgres://"):
+            return url.replace("postgres://", "postgresql+asyncpg://", 1)
+
+        return url
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.core.config import get_settings
 
 settings = get_settings()
-engine = create_async_engine(settings.database_url, echo=False, future=True)
+engine = create_async_engine(settings.async_database_url, echo=False, future=True)
 AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
 
 


### PR DESCRIPTION
## Summary
- add an async_database_url helper that converts DATABASE_URL to an asyncpg DSN when needed
- update the SQLAlchemy session factory to use the async-compatible URL so connections succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3934aa78c8322b0a0b56517cc7f7b