### PR TITLE
Fix async driver detection in async_database_url

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -19,7 +19,9 @@ class Settings(BaseSettings):
 
         url = str(self.database_url)
 
-        if "+" in url:
+        scheme = url.split("://", 1)[0]
+
+        if "+" in scheme:
             return url
 
         if url.startswith("postgresql://"):


### PR DESCRIPTION
## Summary
- check for existing async driver modifiers only in the URL scheme when building async DSNs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d398023c808322bcff176c65e03fb6