### PR TITLE
Wait for database before applying migrations

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Wait for the database to be ready before running migrations
+if [ -n "${DATABASE_URL:-}" ]; then
+  python <<'PYTHON'
+import os
+import time
+
+import psycopg
+
+database_url = os.environ["DATABASE_URL"]
+max_attempts = 30
+
+for attempt in range(1, max_attempts + 1):
+    try:
+        with psycopg.connect(database_url, connect_timeout=5):
+            break
+    except Exception as exc:  # pragma: no cover - diagnostic output only
+        print(f"Waiting for database (attempt {attempt}/{max_attempts}): {exc}")
+        time.sleep(1)
+else:
+    raise SystemExit("Database is not ready")
+PYTHON
+fi
+
 # Apply database migrations
 if command -v alembic >/dev/null 2>&1; then
   alembic upgrade head


### PR DESCRIPTION
## Summary
- wait for the PostgreSQL database to accept connections before launching migrations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39b1627a48322a54c59c4bfef8fff