### PR TITLE
Ensure backend waits for healthy database

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure the database URL is available inside the container
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL environment variable is not set" >&2
+  exit 1
+fi
+
+echo "Using DATABASE_URL=${DATABASE_URL}"
+
 # Wait for the database to be ready before running migrations
 if [ -n "${DATABASE_URL:-}" ]; then
   python <<'PYTHON'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql://app:app@db:5432/app}
       PROJECT_NAME: ${PROJECT_NAME:-myapp}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - ./backend:/app
       - media-data:/media


### PR DESCRIPTION
## Summary
- verify the backend container receives DATABASE_URL by failing fast when it is missing and logging its value
- keep the backend startup process waiting for the database using the supplied URL
- ensure the backend only starts after the database health check passes via depends_on condition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3a5e681888322bf158c01e5938fb0