### PR TITLE
Fix Alembic revision identifier length

### DIFF
--- a/backend/alembic/versions/20241005_add_doc_credentials.py
+++ b/backend/alembic/versions/20241005_add_doc_credentials.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = "20241005_01_add_doctor_login_password"
+revision = "20241005_add_doc_credentials"
 down_revision = "20240919_01_initial_schema"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten the Alembic revision identifier for the doctor credentials migration so it fits into the default 32-character version column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3b39d24148322a12bd96de87b2d62