### PR TITLE
Limit doctor patient list to latest entries with search

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -455,6 +455,28 @@ footer {
   gap: 0.5rem;
 }
 
+.patient-search {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.patient-search-input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  background: #ffffff;
+  font: inherit;
+  color: #1f2937;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.patient-search-input:focus {
+  outline: none;
+  border-color: rgba(79, 70, 229, 0.6);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+}
+
 .panel-description {
   margin: 0;
   color: #4b5563;


### PR DESCRIPTION
## Summary
- show only the five most recently created patients in the doctor dashboard list by default
- add a live search input that highlights up to five matching patients by last and first name
- style the new patient search field to match existing panel visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b744f6648322b5bc6e280f0db8ed