### PR TITLE
Add patient deletion endpoint and hook up UI

### DIFF
--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -608,7 +608,7 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     );
   };
 
-  const handleDeletePatient = (patientId: number) => {
+  const handleDeletePatient = async (patientId: number) => {
     const patient = patients.find((item) => item.id === patientId);
     if (!patient) return;
 
@@ -617,6 +617,20 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     );
 
     if (!confirmed) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/patients/${patientId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete patient');
+      }
+    } catch (error) {
+      console.error(error);
+      window.alert('Не удалось удалить пациента. Попробуйте позже.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a backend DELETE endpoint that removes a patient along with their appointments and disorder links
- wire the doctor dashboard patient deletion button to call the new API and handle failures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ba4e39808322b754203a6d1944ff