### PR TITLE
Tweak doctor dashboard layout and limit completed appointments view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,10 +19,6 @@ const roleContent: Record<Role, RoleContent> = {
     description:
       'Получите доступ к инструментам назначения упражнений и отслеживания прогресса пациентов.',
     redirectMessage: 'После авторизации вы перейдёте в кабинет врача.',
-    demoCredentials: {
-      login: 'klinikanz',
-      password: 'welove23041987',
-    },
   },
   patient: {
     title: 'Вход для пациентов',
@@ -57,7 +53,6 @@ const App = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const doctorDemoCredentials = roleContent.doctor.demoCredentials;
   const patientDemoCredentials = roleContent.patient.demoCredentials;
   const activeRoleContent = activeRole ? roleContent[activeRole] : null;
 
@@ -224,8 +219,8 @@ const App = () => {
         <div className="auth-card">
           <h2>Войдите в платформу</h2>
           <p>
-            Выберите тип доступа, чтобы продолжить. Сейчас доступны демонстрационные учётные записи
-            для врачей и пациентов.
+            Выберите тип доступа, чтобы продолжить. Сейчас доступна демонстрационная учётная запись
+            пациента.
           </p>
           <div className="auth-actions">
             <button type="button" className="auth-button" onClick={() => openModal('doctor')}>
@@ -239,16 +234,11 @@ const App = () => {
               Вход для пациентов
             </button>
           </div>
-          <small className="auth-hint">
-            Демо-доступ:
-            {doctorDemoCredentials
-              ? ` ${doctorDemoCredentials.login}/${doctorDemoCredentials.password}`
-              : ''}
-            {doctorDemoCredentials && patientDemoCredentials ? ' и' : ''}
-            {patientDemoCredentials
-              ? ` ${patientDemoCredentials.login}/${patientDemoCredentials.password}`
-              : ''}
-          </small>
+          {patientDemoCredentials && (
+            <small className="auth-hint">
+              Демо-доступ: {patientDemoCredentials.login}/{patientDemoCredentials.password}
+            </small>
+          )}
         </div>
       </div>
 

--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type Disorder = {
   id: number;
@@ -46,6 +46,9 @@ type DoctorDashboardData = {
   exercises: Exercise[];
   disorderExerciseMap: Record<number, number[]>;
 };
+
+const COMPLETED_INITIAL_COUNT = 6;
+const COMPLETED_BATCH_SIZE = 4;
 
 const transliterate = (value: string) => {
   const map: Record<string, string> = {
@@ -162,6 +165,9 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     minutes: '05',
     seconds: '00',
   });
+  const [completedVisibleCount, setCompletedVisibleCount] = useState(COMPLETED_INITIAL_COUNT);
+  const completedListRef = useRef<HTMLUListElement | null>(null);
+  const previousPatientIdRef = useRef<number | null>(null);
 
   const getLatestPatientId = (list: Patient[]) => {
     if (list.length === 0) {
@@ -694,6 +700,57 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     return { current, future, past } as const;
   }, [selectedPatient]);
 
+  const visibleCompletedAppointments = useMemo(
+    () => appointmentsByStatus.past.slice(0, completedVisibleCount),
+    [appointmentsByStatus.past, completedVisibleCount],
+  );
+
+  useEffect(() => {
+    const total = appointmentsByStatus.past.length;
+    const initialCount = total === 0 ? 0 : Math.min(COMPLETED_INITIAL_COUNT, total);
+
+    if (previousPatientIdRef.current !== selectedPatientId) {
+      previousPatientIdRef.current = selectedPatientId;
+      setCompletedVisibleCount(initialCount);
+      if (completedListRef.current) {
+        completedListRef.current.scrollTop = 0;
+      }
+      return;
+    }
+
+    setCompletedVisibleCount((prev) => {
+      if (total === 0) {
+        return 0;
+      }
+
+      if (prev > total) {
+        return total;
+      }
+
+      return prev;
+    });
+  }, [appointmentsByStatus.past.length, selectedPatientId]);
+
+  const handleCompletedScroll = useCallback(() => {
+    const element = completedListRef.current;
+    if (!element) {
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = element;
+    if (scrollTop + clientHeight < scrollHeight - 16) {
+      return;
+    }
+
+    setCompletedVisibleCount((prev) => {
+      if (prev >= appointmentsByStatus.past.length) {
+        return prev;
+      }
+
+      return Math.min(prev + COMPLETED_BATCH_SIZE, appointmentsByStatus.past.length);
+    });
+  }, [appointmentsByStatus.past.length]);
+
   const renderAppointment = (appointment: Appointment) => {
     const exercise = exercises.find((item) => item.id === appointment.exerciseId);
     const minutes = Math.floor(appointment.durationSeconds / 60)
@@ -728,12 +785,8 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
 
   return (
     <div className="app page doctor-page">
-      <header className="page-header">
-        <h1>Кабинет врача</h1>
-        <p className="lead">
-          Управляйте пациентами, назначайте упражнения и следите за прогрессом прямо из браузера.
-        </p>
-        <div className="doctor-actions">
+      <header className="page-header doctor-header">
+        <div className="doctor-header-top">
           <div className="doctor-stat-cards" role="list">
             <article className="stat-card" role="listitem">
               <span className="stat-label">Пациентов в базе</span>
@@ -748,9 +801,18 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
               <span className="stat-value">{stats.atRisk}</span>
             </article>
           </div>
-          <button type="button" className="secondary-button" onClick={onLogout}>
-            Выйти из кабинета
-          </button>
+
+          <div className="doctor-heading" role="presentation">
+            <div className="doctor-heading-row">
+              <h1>Кабинет врача</h1>
+              <button type="button" className="secondary-button doctor-logout" onClick={onLogout}>
+                Выйти из кабинета
+              </button>
+            </div>
+            <p className="lead">
+              Управляйте пациентами, назначайте упражнения и следите за прогрессом прямо из браузера.
+            </p>
+          </div>
         </div>
         {isLoading && <p className="muted">Загружаем данные кабинета...</p>}
         {loadError && (
@@ -1131,10 +1193,19 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
                   </section>
                   <section>
                     <h4>Завершённые</h4>
-                    <ul className="appointment-list">
-                      {appointmentsByStatus.past.map((appointment) => renderAppointment(appointment))}
+                    <ul
+                      className="appointment-list completed-appointment-list"
+                      onScroll={handleCompletedScroll}
+                      ref={completedListRef}
+                    >
+                      {visibleCompletedAppointments.map((appointment) => renderAppointment(appointment))}
                       {appointmentsByStatus.past.length === 0 && (
                         <li className="muted">Нет завершённых назначений.</li>
+                      )}
+                      {appointmentsByStatus.past.length > visibleCompletedAppointments.length && (
+                        <li className="muted" role="status">
+                          Прокрутите вниз, чтобы посмотреть остальные назначения…
+                        </li>
                       )}
                     </ul>
                   </section>

--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -723,6 +723,10 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
         return 0;
       }
 
+      if (prev === 0) {
+        return initialCount;
+      }
+
       if (prev > total) {
         return total;
       }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -354,6 +354,37 @@ footer {
   max-width: 720px;
 }
 
+.doctor-page .page-header {
+  max-width: none;
+  width: 100%;
+}
+
+.doctor-header-top {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.doctor-heading {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.doctor-heading-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.doctor-logout {
+  margin-left: auto;
+  align-self: flex-start;
+}
+
 .page-body {
   max-width: 720px;
   line-height: 1.7;
@@ -376,14 +407,6 @@ footer {
 .secondary-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 28px rgba(79, 70, 229, 0.25);
-}
-
-.doctor-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .doctor-stat-cards {
@@ -420,6 +443,19 @@ footer {
   font-size: 1.75rem;
   font-weight: 700;
   color: #1f2937;
+}
+
+.completed-appointment-list {
+  max-height: 20rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  scroll-behavior: smooth;
+}
+
+.completed-appointment-list li:last-child.muted {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #6b7280;
 }
 
 .doctor-layout {


### PR DESCRIPTION
## Summary
- remove the doctor demo credential mention from the landing overlay copy
- rearrange the doctor dashboard header to place stats beside the title and move the logout button to the top-right
- cap the completed appointments list with a scrollable view that loads more items on demand and adds supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f2c826e883229e9b421824e72a2f