### PR TITLE
Move doctor dashboard stats next to heading

### DIFF
--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -791,6 +791,17 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     <div className="app page doctor-page">
       <header className="page-header doctor-header">
         <div className="doctor-header-top">
+          <div className="doctor-heading" role="presentation">
+            <div className="doctor-heading-row">
+              <h1>Кабинет врача</h1>
+              <button type="button" className="secondary-button doctor-logout" onClick={onLogout}>
+                Выйти из кабинета
+              </button>
+            </div>
+            <p className="lead">
+              Управляйте пациентами, назначайте упражнения и следите за прогрессом прямо из браузера.
+            </p>
+          </div>
           <div className="doctor-stat-cards" role="list">
             <article className="stat-card" role="listitem">
               <span className="stat-label">Пациентов в базе</span>
@@ -804,18 +815,6 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
               <span className="stat-label">Низкий прогресс</span>
               <span className="stat-value">{stats.atRisk}</span>
             </article>
-          </div>
-
-          <div className="doctor-heading" role="presentation">
-            <div className="doctor-heading-row">
-              <h1>Кабинет врача</h1>
-              <button type="button" className="secondary-button doctor-logout" onClick={onLogout}>
-                Выйти из кабинета
-              </button>
-            </div>
-            <p className="lead">
-              Управляйте пациентами, назначайте упражнения и следите за прогрессом прямо из браузера.
-            </p>
           </div>
         </div>
         {isLoading && <p className="muted">Загружаем данные кабинета...</p>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -413,6 +413,8 @@ footer {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .stat-card {


### PR DESCRIPTION
## Summary
- rearranged the doctor dashboard header to show the stats beside the "Кабинет врача" heading
- updated the header layout styles to right-align the statistic cards next to the heading

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3fbd5e7f08322800e16dbb08e5dfd