### PR TITLE
Add cognitive status filters for recommended exercises

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -717,6 +717,18 @@ footer {
   flex-wrap: wrap;
 }
 
+.cognitive-status-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cognitive-status-title {
+  font-weight: 600;
+  color: #1f2937;
+}
+
 .exercise-counter {
   font-weight: 600;
   color: #1f2937;


### PR DESCRIPTION
## Summary
- add cognitive status filter controls when showing recommended exercises
- filter recommended exercises to active or passive based on cognitive status selection
- style the new cognitive status filter controls in the assign exercises toolbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d414b9a43483228eae28e0cf9dc240