### PR TITLE
Add database viewer to doctor dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "palsy-video-training-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "ag-grid-community": "^34.2.0",
+        "ag-grid-react": "^34.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1144,6 +1146,35 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/ag-charts-types": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-12.2.0.tgz",
+      "integrity": "sha512-d2qQrQirt9wP36YW5HPuOvXsiajyiFnr1CTsoCbs02bavPDz7Lk2jHp64+waM4YKgXb3GN7gafbBI9Qgk33BmQ==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-community": {
+      "version": "34.2.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-34.2.0.tgz",
+      "integrity": "sha512-peS7THEMYwpIrwLQHmkRxw/TlOnddD/F5A88RqlBxf8j+WqVYRWMOOhU5TqymGcha7z2oZ8IoL9ROl3gvtdEjg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "12.2.0"
+      }
+    },
+    "node_modules/ag-grid-react": {
+      "version": "34.2.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-34.2.0.tgz",
+      "integrity": "sha512-dLKFw6hz75S0HLuZvtcwjm+gyiI4gXVzHEu7lWNafWAX0mb8DhogEOP5wbzAlsN6iCfi7bK/cgZImZFjenlqwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-grid-community": "34.2.0",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -1409,6 +1440,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1445,6 +1485,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1469,6 +1520,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "ag-grid-community": "^34.2.0",
+    "ag-grid-react": "^34.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -380,8 +380,29 @@ footer {
   flex-wrap: wrap;
 }
 
-.doctor-logout {
+.doctor-actions {
   margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.doctor-actions .secondary-button {
+  align-self: stretch;
+}
+
+.doctor-actions.horizontal {
+  flex-direction: row;
+  align-items: center;
+}
+
+.doctor-actions.horizontal .secondary-button {
+  align-self: auto;
+}
+
+.doctor-logout {
+  margin-left: 0;
   align-self: flex-start;
 }
 
@@ -465,6 +486,10 @@ footer {
   align-items: flex-start;
 }
 
+.database-layout {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .doctor-column {
   display: flex;
   flex-direction: column;
@@ -483,6 +508,49 @@ footer {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.database-panel {
+  min-height: 0;
+  gap: 1rem;
+}
+
+.database-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.database-label {
+  min-width: 220px;
+}
+
+.database-select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(79, 70, 229, 0.3);
+  background: #f9fafb;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.database-select:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+}
+
+.database-grid-wrapper {
+  flex: 1;
+  min-height: 24rem;
+}
+
+.database-grid {
+  height: 100%;
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
 }
 
 .panel-header {
@@ -798,6 +866,11 @@ footer {
   }
 
   .doctor-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .doctor-actions.horizontal {
     flex-direction: column;
     align-items: stretch;
   }


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to enumerate database tables and fetch paged table data with value serialization
- integrate an AG Grid powered database viewer into the doctor dashboard with a navigation button and infinite scrolling
- style the new database view and action buttons, and add AG Grid dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e68cfb1483229398efcb4af085ae