### PR TITLE
Add Ruff lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ruff:
+    name: Run Ruff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt ruff
+
+      - name: Run Ruff
+        run: ruff check backend


### PR DESCRIPTION
## Summary
- add a Ruff-based lint workflow that runs on pushes to main and pull requests

## Testing
- not run (CI only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4f258ab4c8322accf4bef11cd17c8