### PR TITLE
Add patient disorder saving API and update doctor dashboard layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -437,6 +437,14 @@ footer {
   box-shadow: 0 16px 28px rgba(79, 70, 229, 0.25);
 }
 
+.secondary-button:disabled,
+.secondary-button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
 .doctor-stat-cards {
   display: flex;
   flex-wrap: wrap;
@@ -757,6 +765,31 @@ footer {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.patient-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.patient-section-message {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+}
+
+.patient-section-message.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #166534;
+}
+
+.patient-section-message.error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
 }
 
 .disorder-groups,


### PR DESCRIPTION
## Summary
- add a backend endpoint to persist patient disorders with per-category validation
- update the doctor dashboard to enforce single selections per disorder type, add a save button, and move the active patients card next to the patient list
- refresh styles for the new controls and disabled states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f626c3508322bf703c1903948555