### PR TITLE
Align active patients card with patient list

### DIFF
--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -1806,12 +1806,12 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
           </div>
         </section>
 
-        <section className="doctor-column wide" aria-live="polite">
+        <section className="doctor-column" aria-labelledby="active-patients-heading">
           <div className="panel" aria-labelledby="active-patients-heading">
             <header className="panel-header">
               <h2 id="active-patients-heading">Активные пациенты</h2>
               <p className="panel-description">
-                Сейчас выполняют программу:{' '}
+                Сейчас выполняют программу{' '}
                 {isLoading ? 'загрузка…' : activePatients.length || 'нет данных'}
               </p>
             </header>
@@ -1840,6 +1840,9 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
               )}
             </ul>
           </div>
+        </section>
+
+        <section className="doctor-column wide" aria-live="polite">
           {isLoading ? (
             <div className="panel">
               <header className="panel-header">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -512,7 +512,7 @@ footer {
 }
 
 .doctor-column.wide {
-  grid-column: span 2;
+  grid-column: 1 / -1;
 }
 
 .panel {
@@ -897,7 +897,7 @@ footer {
   }
 
   .doctor-column.wide {
-    grid-column: span 2;
+    grid-column: 1 / -1;
   }
 }
 
@@ -907,7 +907,7 @@ footer {
   }
 
   .doctor-column.wide {
-    grid-column: span 1;
+    grid-column: 1 / -1;
   }
 
   .doctor-actions {


### PR DESCRIPTION
## Summary
- place the active patients panel in its own column so it aligns with the add and patient list cards on the doctor dashboard
- update the wide column styling so patient details stretch across the full layout below the top row

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fbe21df08322ac31142a0527ec17