### PR TITLE
Treat disorder exercise links as exclusions

### DIFF
--- a/frontend/src/DoctorDashboard.tsx
+++ b/frontend/src/DoctorDashboard.tsx
@@ -478,7 +478,7 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
     }, {});
   }, [disorders]);
 
-  const recommendedExercises = useMemo(() => {
+  const excludedExercises = useMemo(() => {
     if (!selectedPatient) {
       return new Set<number>();
     }
@@ -526,8 +526,8 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
   const categorizedExercises = useMemo(() => {
     return exercises.reduce<Record<string, Exercise[]>>((acc, exercise) => {
       if (showOnlyRecommended && selectedPatient) {
-        const recommended = recommendedExercises.has(exercise.id);
-        if (!recommended) {
+        const excluded = excludedExercises.has(exercise.id);
+        if (excluded) {
           return acc;
         }
       }
@@ -538,7 +538,7 @@ const DoctorDashboard = ({ onLogout }: DoctorDashboardProps) => {
       acc[exercise.type].push(exercise);
       return acc;
     }, {});
-  }, [exercises, recommendedExercises, selectedPatient, showOnlyRecommended]);
+  }, [exercises, excludedExercises, selectedPatient, showOnlyRecommended]);
 
   const resetForm = () => {
     setNewPatient({


### PR DESCRIPTION
## Summary
- invert the memoized set built from `disorderExerciseMap` so it tracks excluded exercises
- skip any excluded exercises from the filtered view when showing patient-specific recommendations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60132a130832281d4febd73643fd5