### PR TITLE
Add category select checkboxes for patient exercises

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -807,10 +807,28 @@ footer {
   background: #f9fafb;
 }
 
-.disorder-group h4,
-.exercise-group h4 {
+.disorder-group h4 {
   margin: 0 0 0.75rem;
   font-size: 1rem;
+}
+
+.exercise-group h4 {
+  font-size: 1rem;
+}
+
+.exercise-group-header {
+  margin: 0 0 0.75rem;
+}
+
+.exercise-group-checkbox {
+  width: 100%;
+}
+
+.exercise-group-checkbox h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
 }
 
 .disorder-group ul,


### PR DESCRIPTION
## Summary
- add category-level checkboxes when assigning exercises to patients
- ensure partial selections show indeterminate state and update selections in bulk
- tweak exercise group styles to accommodate the new checkbox header layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60a123e9c832283602144f726ace3