### PR TITLE
Add media storage and video upload endpoints

### DIFF
--- a/backend/alembic/versions/20241010_add_video_storage_columns.py
+++ b/backend/alembic/versions/20241010_add_video_storage_columns.py
@@ -1,0 +1,40 @@
+"""Add storage metadata for videos"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20241010_add_video_storage_columns"
+down_revision = "20241009_add_video_metadata_fields"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "videos"
+FILE_PATH_COLUMN = "file_path"
+MIME_TYPE_COLUMN = "mime_type"
+FILENAME_COLUMN = "filename"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(TABLE_NAME) as batch_op:
+        batch_op.alter_column(
+            FILENAME_COLUMN,
+            existing_type=sa.String(length=45),
+            type_=sa.Text(),
+        )
+        batch_op.add_column(sa.Column(FILE_PATH_COLUMN, sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column(MIME_TYPE_COLUMN, sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table(TABLE_NAME) as batch_op:
+        batch_op.drop_column(MIME_TYPE_COLUMN)
+        batch_op.drop_column(FILE_PATH_COLUMN)
+        batch_op.alter_column(
+            FILENAME_COLUMN,
+            existing_type=sa.Text(),
+            type_=sa.String(length=45),
+        )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,8 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     project_name: str = "myapp"
     database_url: PostgresDsn
+    media_root: str = "/media"
+    media_url: str = "/media"
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/core/media.py
+++ b/backend/app/core/media.py
@@ -1,0 +1,141 @@
+"""Utilities for storing uploaded media files."""
+
+from __future__ import annotations
+
+import mimetypes
+import secrets
+from pathlib import Path
+from typing import Final
+
+from fastapi import UploadFile
+
+from app.core.config import get_settings
+
+__all__ = [
+    "ALLOWED_VIDEO_EXTENSIONS",
+    "build_public_url",
+    "delete_media_file",
+    "generate_unique_filename",
+    "resolve_extension",
+    "save_video_upload",
+]
+
+
+CHUNK_SIZE: Final[int] = 1024 * 1024
+ALLOWED_VIDEO_EXTENSIONS: Final[set[str]] = {
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".webm",
+}
+
+_MIME_BY_EXTENSION: Final[dict[str, str]] = {
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".webm": "video/webm",
+}
+_EXTENSION_BY_MIME: Final[dict[str, str]] = {
+    mime: extension for extension, mime in _MIME_BY_EXTENSION.items()
+}
+
+
+def _media_root() -> Path:
+    settings = get_settings()
+    return Path(settings.media_root)
+
+
+def _video_directory() -> Path:
+    directory = _media_root() / "videos"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def resolve_extension(filename: str | None, content_type: str | None) -> str:
+    """Return a safe, allowed file extension for an uploaded file."""
+
+    if filename:
+        ext = Path(filename).suffix.lower()
+        if ext in ALLOWED_VIDEO_EXTENSIONS:
+            return ext
+
+    if content_type:
+        normalized = content_type.split(";", 1)[0].strip().lower()
+        if normalized in _EXTENSION_BY_MIME:
+            return _EXTENSION_BY_MIME[normalized]
+        guessed = mimetypes.guess_extension(normalized)
+        if guessed and guessed.lower() in ALLOWED_VIDEO_EXTENSIONS:
+            return guessed.lower()
+
+    allowed = ", ".join(sorted(ALLOWED_VIDEO_EXTENSIONS))
+    raise ValueError(f"Недопустимое расширение файла. Разрешены: {allowed}.")
+
+
+def generate_unique_filename(extension: str) -> str:
+    """Generate a random filename with the provided extension."""
+
+    safe_extension = extension if extension.startswith(".") else f".{extension}"
+    token = secrets.token_urlsafe(16)
+    return f"{token}{safe_extension.lower()}"
+
+
+async def save_video_upload(upload: UploadFile) -> tuple[str, str]:
+    """Persist an uploaded video and return its relative path and MIME type."""
+
+    try:
+        extension = resolve_extension(upload.filename, upload.content_type)
+        filename = generate_unique_filename(extension)
+        directory = _video_directory()
+        destination = directory / filename
+
+        with destination.open("wb") as buffer:
+            while True:
+                chunk = await upload.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                buffer.write(chunk)
+    finally:
+        await upload.close()
+
+    relative_path = str(Path("videos") / filename)
+    content_type = (upload.content_type or "").split(";", 1)[0].strip().lower()
+    mime_type = _MIME_BY_EXTENSION.get(extension, None)
+    if content_type:
+        if content_type in _EXTENSION_BY_MIME:
+            mime_type = content_type
+        else:
+            guess = mimetypes.guess_extension(content_type)
+            if guess and guess.lower() == extension:
+                mime_type = content_type
+    if not mime_type:
+        mime_type = _MIME_BY_EXTENSION.get(extension, "application/octet-stream")
+
+    return relative_path, mime_type
+
+
+def delete_media_file(relative_path: str | None) -> None:
+    """Remove a media file stored under the configured media root."""
+
+    if not relative_path:
+        return
+    media_root = _media_root().resolve()
+    candidate = (media_root / Path(relative_path)).resolve()
+    try:
+        candidate.relative_to(media_root)
+    except ValueError:
+        # Prevent path traversal outside the media root.
+        return
+    candidate.unlink(missing_ok=True)
+
+
+def build_public_url(relative_path: str | None) -> str | None:
+    """Compose a publicly accessible URL for a stored media file."""
+
+    if not relative_path:
+        return None
+    settings = get_settings()
+    base = settings.media_url.rstrip("/")
+    suffix = str(relative_path).lstrip("/")
+    if not base:
+        return f"/{suffix}"
+    return f"{base}/{suffix}"


### PR DESCRIPTION
## Summary
- add configurable media storage paths and helper utilities for saving uploaded video files with validation
- expose FastAPI endpoints for uploading videos and retrieving their metadata, and surface the generated URLs in dashboard responses
- extend the `videos` table via Alembic migration with file path and MIME type fields to support the new media workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61cfc82248322b399dc3e4368ad8a