### PR TITLE
Add python-multipart dependency for FastAPI file uploads

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 pydantic-settings==2.2.1
 psycopg[binary]==3.1.18
 bcrypt==4.2.0
+python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- add python-multipart to backend requirements so FastAPI file upload endpoints work during startup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d621da5838832296a627f4a380901d