### PR TITLE
Serve media assets through Caddy file handler

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,11 @@ palsy-training.ru {
             reverse_proxy backend:8000
         }
 
+        handle /media/* {
+            root * /media
+            file_server browse
+        }
+
         handle {
             # Раздаём собранный фронтенд
             root * /srv


### PR DESCRIPTION
## Summary
- add a dedicated /media handler in Caddy that serves files from the media volume

## Testing
- not run (environment does not provide Docker)

------
https://chatgpt.com/codex/tasks/task_e_68d622db5d28832288fc24babe0dc956