### PR TITLE
Fix patient login username normalization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -554,7 +554,7 @@ async def _require_patient_authorization(
 async def patient_login(
     payload: PatientLoginRequest, db: AsyncSession = Depends(get_session)
 ) -> PatientLoginResponse:
-    username = _filter_alpha_numeric(payload.username.strip())
+    username = payload.username.strip()
     password = payload.password.strip()
 
     if not username or not password:


### PR DESCRIPTION
## Summary
- stop stripping punctuation when authenticating patients so generated usernames with dots continue to work

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6262e4348832291aa39c05a4e726a