### PR TITLE
Fix playlist player video reload on selection change

### DIFF
--- a/frontend/src/PatientDashboard.tsx
+++ b/frontend/src/PatientDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 export type PatientSessionProfile = {
   id: number;
@@ -109,6 +109,7 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
   const [error, setError] = useState('');
   const [reloadCounter, setReloadCounter] = useState(0);
   const [selectedAppointmentIndex, setSelectedAppointmentIndex] = useState(0);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
     let isActive = true;
@@ -215,6 +216,12 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
   const selectedAppointment = appointments[selectedAppointmentIndex];
 
   useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.load();
+    }
+  }, [selectedAppointment?.id, selectedAppointment?.videoUrl, selectedAppointment?.mimeType]);
+
+  useEffect(() => {
     if (!appointments.length) {
       if (selectedAppointmentIndex !== 0) {
         setSelectedAppointmentIndex(0);
@@ -310,7 +317,13 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
                         </header>
                         <div className="patient-dashboard__player-media">
                           {selectedAppointment.videoUrl ? (
-                            <video controls preload="metadata" width="100%">
+                            <video
+                              key={selectedAppointment.id}
+                              ref={videoRef}
+                              controls
+                              preload="metadata"
+                              width="100%"
+                            >
                               <source
                                 src={selectedAppointment.videoUrl}
                                 type={selectedAppointment.mimeType ?? undefined}


### PR DESCRIPTION
## Summary
- ensure the playlist video element reloads when the selected appointment changes by invoking load on the underlying tag
- tie the video element instance to the appointment id so a newly selected exercise remounts correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d65ca436248322864e9abd87c0603a