### PR TITLE
Style patient dashboard sections as rounded cards

### DIFF
--- a/frontend/src/PatientDashboard.tsx
+++ b/frontend/src/PatientDashboard.tsx
@@ -266,7 +266,7 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
 
         {!loading && !error && (
           <>
-            <section className="section">
+            <section className="section patient-dashboard__section">
               <h2>Ваш прогресс</h2>
               {appointments.length ? (
                 <div className="patient-dashboard__summary-grid">
@@ -288,7 +288,7 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
               )}
             </section>
 
-            <section className="section">
+            <section className="section patient-dashboard__section">
               <h2>Назначения</h2>
               {appointments.length === 0 ? (
                 <p>
@@ -404,7 +404,7 @@ const PatientDashboard = ({ token, patient, onLogout }: PatientDashboardProps) =
               )}
             </section>
 
-            <section className="section">
+            <section className="section patient-dashboard__section">
               <h2>Все упражнения</h2>
               {exercises.length === 0 ? (
                 <p>Список упражнений пока пуст.</p>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -995,6 +995,23 @@ footer {
   padding-bottom: 4rem;
 }
 
+.patient-dashboard__section {
+  margin: 1.5rem clamp(1.5rem, 4vw, 4rem) 0;
+  padding: 2rem clamp(1.5rem, 4vw, 4rem);
+  border-radius: 1.5rem;
+  background: white;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.patient-dashboard__section:first-of-type {
+  margin-top: 0;
+}
+
+.patient-dashboard__section + .patient-dashboard__section {
+  border-top: none;
+}
+
 .patient-dashboard__summary-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));


### PR DESCRIPTION
## Summary
- add a dedicated class to patient dashboard sections to align with the rounded card design used elsewhere
- style patient sections with rounded corners, subtle borders, and shadows for consistent card appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65eeefbb48322aade04ff7b0ac007